### PR TITLE
hotfix: env detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,19 +110,19 @@ My setup uses multiple plugins. I use [Vim Plug](https://github.com/junegunn/vim
 
 - Awesome Colorschemes
   - URL: https://github.com/rafi/awesome-vim-colorschemes
-  - Plug Install: Plug 'rafi/awesome-vim-colorschemes'
+  - Plug Install: `Plug 'rafi/awesome-vim-colorschemes'`
 
 - Colorschemes
   - URL: https://github.com/flazz/vim-colorschemes'
-  - Plug Install: Plug 'flazz/vim-colorschemes' 
+  - Plug Install: `Plug 'flazz/vim-colorschemes' `
 
 - Vim-Themes
   - URL: https://github.com/mswift42/vim-themes
-  - Plug Install: Plug 'mswift42/vim-themes'
+  - Plug Install: `Plug 'mswift42/vim-themes'`
 
 - Highlighted yank
   - URL: https://github.com/machakann/vim-highlightedyank
-  - Plug Install: Plug 'machakann/vim-highlightedyank'
+  - Plug Install: `Plug 'machakann/vim-highlightedyank'`
 
 ### Will/Might Try
 

--- a/nvim_config/conf/environment.vim
+++ b/nvim_config/conf/environment.vim
@@ -1,11 +1,11 @@
 " Environment detection {{{
-if has("win32") || has("win64")
-    let g:plugged_home = "~/AppData/Local/nvim/plugged"
+" if has("win32") || has("win64")
+"     let g:plugged_home = "~/AppData/Local/nvim/plugged"
 
-else
-    let g:plugged_home = "~/.local/share/nvim/plugged"
+" else
+"     let g:plugged_home = "~/.local/share/nvim/plugged"
 
-endif
+" endif
 
 "}}}
 
@@ -151,13 +151,26 @@ set nowritebackup
 
 
 " session management
-if has("win32") || has("win64")
+let g:session_directory = g:d_nvim_base . '/session'
 
-    let g:session_directory = "~/AppData/Local/nvim/session"
+" if has("win32") || has("win64")
 
-elseif has("unix")
+"     let g:session_directory = '~/AppData/Local/nvim/session'
 
-    let g:session_directory = "~/.config/nvim/session"
+" elseif has("unix")
+
+"     let g:session_directory = '~/.config/nvim/session'
+
+"     " Tries to set shell from env, defaults to bash
+"     if exists("$SHELL")
+"         set shell=$SHELL
+"     else
+"         set shell=/bin/sh
+"     endif
+
+" end
+
+if has("unix")
 
     " Tries to set shell from env, defaults to bash
     if exists("$SHELL")

--- a/nvim_config/conf/environment.vim
+++ b/nvim_config/conf/environment.vim
@@ -170,7 +170,7 @@ let g:session_directory = g:d_nvim_base . '/session'
 
 " end
 
-if has("unix")
+if g:uname == 'Linux' || g:uname == 'Darwin'
 
     " Tries to set shell from env, defaults to bash
     if exists("$SHELL")

--- a/nvim_config/conf/plugin-conf/ctrlspace-conf.vim
+++ b/nvim_config/conf/plugin-conf/ctrlspace-conf.vim
@@ -3,24 +3,24 @@
 if has('win32')
     " Windows Environment
 
-    let s:vimfiles = '~/AppData/Local/nvim-data'
-    let s:os   = 'windows'
+    let g:vimfiles = '~/AppData/Local/nvim-data'
+    let g:os   = 'windows'
 
 else
     " Linux/Mac Environment
 
-    let s:vimfiles = '~/.vim'
+    let g:vimfiles = '~/.vim'
     
     if has('mac') || has('gui_macvim')
-        let s:os = 'darwin'
+        let g:os = 'darwin'
     else
     " elseif has('gui_gtk2') || has('gui_gtk3')
-        let s:os = 'linux'
+        let g:os = 'linux'
     endif
 
 endif
 
-let g:CtrlSpaceFileEngine = s:vimfiles . '/plugged/vim-ctrlspace' . '/bin/file_engine_' . s:os . '_amd64'
+let g:CtrlSpaceFileEngine = g:vimfiles . '/plugged/vim-ctrlspace' . '/bin/file_engine_' . g:os . '_amd64'
 
 " Turn tabline off
 set showtabline=0

--- a/nvim_config/conf/vimplug/vimplug-core.vim
+++ b/nvim_config/conf/vimplug/vimplug-core.vim
@@ -59,33 +59,51 @@
 
     call plug#begin(g:plugged_home)
 
-        if has("win32") || has("win64")
-            " Windows environment
-
-            " Include user's extra bundle(s)
-            if filereadable(expand('~/AppData/Local/nvim/local_bundles.vim'))
-                source ~/AppData/Local/nvim/local_bundles.vim
-            endif
-
-            " Source vim plugin installs
-            if filereadable(expand('~/AppData/Local/nvim/conf/vimplug/plug-installs.vim'))
-                source ~/AppData/Local/nvim/conf/vimplug/plug-installs.vim
-            end
-
-        elseif has("unix")
-            " Linux/Mac environment
-
-            " Include user's extra bundle(s)
-            if filereadable(expand('~/.config/nvim/local_bundles.vim'))
-                source ~/.config/nvim/local_bundles.vim
-            endif
-
-            " Source vim plugin installs
-            if filereadable(expand('~/.config/nvim/conf/vimplug/plug-installs.vim'))
-                source ~/.config/nvim/conf/vimplug/plug-installs.vim
-            end
-
+        " Include user's extra bundle(s)
+        " if filereadable(expand('~/AppData/Local/nvim/local_bundles.vim'))
+        if filereadable(expand(g:d_nvim_base . '/local_bundles.vim'))
+            " source ~/AppData/Local/nvim/local_bundles.vim
+            source g:d_nvim_base . '/local_bundles.vim'
         endif
+
+        " Source vim plugin installs
+        " if filereadable(expand('~/AppData/Local/nvim/conf/vimplug/plug-installs.vim'))
+        if filereadable(expand(g:d_vimplug_conf . '/plug_installs.vim'))
+            " source ~/AppData/Local/nvim/conf/vimplug/plug-installs.vim
+            source g:d_vimplug_conf . '/plug_installs.vim'
+        end
+
+        " if has("win32") || has("win64")
+        "     " Windows environment
+
+        "     " Include user's extra bundle(s)
+        "     " if filereadable(expand('~/AppData/Local/nvim/local_bundles.vim'))
+        "     if filereadable(expand(g:d_nvim_base . '/local_bundles.vim'))
+        "         " source ~/AppData/Local/nvim/local_bundles.vim
+        "         source g:d_nvim_base . '/local_bundles.vim'
+        "     endif
+
+        "     " Source vim plugin installs
+        "     " if filereadable(expand('~/AppData/Local/nvim/conf/vimplug/plug-installs.vim'))
+        "     if filereadable(expand(g:d_vimplug_conf . '/plug_installs.vim'))
+        "         " source ~/AppData/Local/nvim/conf/vimplug/plug-installs.vim
+        "         source g:d_vimplug_conf . '/plug_installs.vim'
+        "     end
+
+        " elseif has("unix")
+        "     " Linux/Mac environment
+
+        "     " Include user's extra bundle(s)
+        "     if filereadable(expand('~/.config/nvim/local_bundles.vim'))
+        "         source ~/.config/nvim/local_bundles.vim
+        "     endif
+
+        "     " Source vim plugin installs
+        "     if filereadable(expand('~/.config/nvim/conf/vimplug/plug-installs.vim'))
+        "         source ~/.config/nvim/conf/vimplug/plug-installs.vim
+        "     end
+
+        " endif
 
     " End Vim plug
     call plug#end()

--- a/nvim_config/conf/vimplug/vimplug-core.vim
+++ b/nvim_config/conf/vimplug/vimplug-core.vim
@@ -4,12 +4,78 @@
         set nocompatible " Be iMproved
     endif
 
-    if has("win32") || has("win64")
-        " Windows Vim Plug setup
+    " if has("win32") || has("win64")
+    "     " Windows Vim Plug setup
 
+    "     let g:plugged_home = '~/AppData/Local/nvim-data/plugged'
+
+    "     let vimplug_exists=expand('~/AppData/Local/nvim/autoload/plug.vim')
+
+    "     let g:vim_bootstrap_langs = 'python'
+    "     let g:vim_bootstrap_editor = 'nvim'
+
+    "     " Install vim-plug if it's not already installed {{{
+
+    "         if !filereadable(vimplug_exists)
+    "             echo 'Installing Vim Plug...'
+    "             echo '
+    "             silent !\curl -fLo ~/AppData/Local/nvim/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+    "             let g:not_finish_vimplug = 'yes'
+
+    "             autocmd VimEnter * PlugInstall
+    "         endif
+
+    "     "}}}
+
+    " elseif has('unix')
+    "     " Linux/Mac environment
+
+    "     let g:plugged_home = '~/.local/share/nvim/plugged'
+
+    "     let vimplug_exists=expand('~/.config/nvim/autoload/plug.vim')
+
+    "     let g:vim_bootstrap_langs = 'python'
+    "     let g:vim_bootstrap_editor = 'nvim'
+
+    "     " Install vim-plug if it's not already installed {{{
+
+    "     if !filereadable(vimplug_exists)
+    "         echo 'Installing Vim Plug...'
+    "         echo '
+    "         silent !\curl -fLo ~/.config/nvim/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+    "         let g:not_finish_vimplug = "yes"
+
+    "         autocmd VimEnter * PlugInstall
+    "     endif
+
+    "     "}}}
+
+    " endif
+
+    if has('linux') || has('mac')
+            " Linux/Mac environment
+
+        let g:plugged_home = '~/.local/share/nvim/plugged'
+
+        let vimplug_exists=expand('g:d_autoload_conf' . '/plug.vim')
+
+        let g:vim_bootstrap_langs = 'python'
+        let g:vim_bootstrap_editor = 'nvim'
+
+        " Install vim-plug if it's not already installed {{{
+
+        if !filereadable(vimplug_exists)
+            echo 'Installing Vim Plug...'
+            echo '
+            silent !\curl -fLo g:d_autoload_conf . '/plug.vim' --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+            let g:not_finish_vimplug = "yes"
+
+            autocmd VimEnter * PlugInstall
+        endif
+    elseif has('win32') || has('win64')
         let g:plugged_home = '~/AppData/Local/nvim-data/plugged'
 
-        let vimplug_exists=expand('~/AppData/Local/nvim/autoload/plug.vim')
+        let vimplug_exists=expand('g:d_autoload_conf' . '/plug.vim')
 
         let g:vim_bootstrap_langs = 'python'
         let g:vim_bootstrap_editor = 'nvim'
@@ -24,33 +90,7 @@
 
                 autocmd VimEnter * PlugInstall
             endif
-
-        "}}}
-
-    elseif has('unix')
-        " Linux/Mac environment
-
-        let g:plugged_home = '~/.local/share/nvim/plugged'
-
-        let vimplug_exists=expand('~/.config/nvim/autoload/plug.vim')
-
-        let g:vim_bootstrap_langs = 'python'
-        let g:vim_bootstrap_editor = 'nvim'
-
-        " Install vim-plug if it's not already installed {{{
-
-        if !filereadable(vimplug_exists)
-            echo 'Installing Vim Plug...'
-            echo '
-            silent !\curl -fLo ~/.config/nvim/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
-            let g:not_finish_vimplug = "yes"
-
-            autocmd VimEnter * PlugInstall
-        endif
-
-        "}}}
-
-    endif
+    end
 
 "}}}
 

--- a/nvim_config/init.vim
+++ b/nvim_config/init.vim
@@ -6,6 +6,8 @@
 "   from files in the conf/ directory. I do my best to make commands cross-platform
 "   (sometimes disabling features, if they aren't available on a certain platform).
 "
+" Variables with a d_ are for dir paths, f_ are for file paths, and p_ are for plugins.
+"
 " NOTE FOR MAC USERS: None of this configuration is tested on Mac.
 "
 
@@ -27,28 +29,66 @@
 " endif
 "
 
+if has('win32') || has('win64')
+    " Set nvim conf base directory paths for Windows environments
+
+    let g:d_nvim_base = '~/AppData/Local/nvim'
+
+elseif has('unix')
+    " Set nvim conf base directory path for Linux environments
+
+    let g:d_nvim_base = '~/.config/nvim'
+
+end
+
+" Set path to autoload/ with vim-plug's autoload script
+let g:d_autoload_conf = g:d_nvim_base . '/autoload'
+" Set path to colors/ dir with colorscheme files
+let g:d_colorschemes_conf = g:d_nvim_base . '/colors'
+" Set path to conf/ dir with core config files
+let g:d_nvim_conf = g:d_nvim_base . '/conf'
+" Set path to conf/vimplug/
+let g:d_vimplug_conf = g:d_nvim_conf . '/vimplug'
+" Set path to conf/vimplug/plugin-conf dir
+let g:d_vimplug_plugin_conf = g:d_vimplug_conf . '/plugin-conf'
+
+" Set script vars (local to init.vim) for *.vim files
+let s:f_environment_vim = g:d_nvim_conf . '/environment.vim'
+let s:f_key_mappings_vim = g:d_nvim_conf . '/key-mappings.vim'
+let s:f_autocmd_rules_vim = g:d_nvim_conf . '/autocmd-rules.vim'
+let s:f_vimplug_core = g:d_vimplug_conf . '/vimplug-core.vim'
+let s:f_plug_installs = g:d_vimplug_conf . '/plug-installs.vim'
+
 
 " Environment
-if filereadable(expand('~/AppData/Local/nvim/conf/environment.vim'))
-    source ~/AppData/Local/nvim/conf/environment.vim
+" if filereadable(expand('~/AppData/Local/nvim/conf/environment.vim'))
+if filereadable(expand(s:f_environment_vim))
+    " source ~/AppData/Local/nvim/conf/environment.vim
+    source s:f_environment_vim
 end
 
 " Mappings
-if filereadable(expand('~/AppData/Local/nvim/conf/key-mappings.vim'))
-    source ~/AppData/Local/nvim/conf/key-mappings.vim
+" if filereadable(expand('~/AppData/Local/nvim/conf/key-mappings.vim'))
+if filereadable(expand(s:f_key_mappings_vim))
+    " source ~/AppData/Local/nvim/conf/key-mappings.vim
+    source s:f_key_mappings_vim
 end
 
 " autocmd Rules
-if filereadable(expand('~/AppData/Local/nvim/conf/autocmd-rules.vim'))
-    source ~/AppData/Local/nvim/conf/autocmd-rules.vim
+" if filereadable(expand('~/AppData/Local/nvim/conf/autocmd-rules.vim'))
+if filereadable(expand(s:f_autocmd_rules_vim))
+    " source ~/AppData/Local/nvim/conf/autocmd-rules.vim
+    source s:f_autocmd_rules_vim
 end
 
 " Vim Plug plugin manager
-if filereadable(expand('~/AppData/Local/nvim/conf/vimplug/vimplug-core.vim'))
-    source ~/AppData/Local/nvim/conf/vimplug/vimplug-core.vim
+" if filereadable(expand('~/AppData/Local/nvim/conf/vimplug/vimplug-core.vim'))
+if filereadable(expand(s:f_vimplug_core))
+    " source ~/AppData/Local/nvim/conf/vimplug/vimplug-core.vim
 end
 
 " Loop over plugin configurations
-for f in split(glob('~/AppData/Local/nvim/conf/plugin-conf/*.vim'), '\n')
+" for f in split(glob('~/AppData/Local/nvim/conf/plugin-conf/*.vim'), '\n')
+for f in split(glob(s:d_vimplug_plugin_conf), '\n')
     exe 'source' f
 endfor

--- a/nvim_config/init.vim
+++ b/nvim_config/init.vim
@@ -29,16 +29,25 @@
 " endif
 "
 
-if has('win32') || has('win64')
-    " Set nvim conf base directory paths for Windows environments
+" Check OS nvim is running on
+let g:uname = substitute(system('uname'), '\n', '', '')
 
-    let g:d_nvim_base = '~/AppData/Local/nvim'
+" if has('win32') || has('win64')
+"     " Set nvim conf base directory paths for Windows environments
 
-elseif has('unix')
-    " Set nvim conf base directory path for Linux environments
+"     let g:d_nvim_base = '~/AppData/Local/nvim'
 
+" elseif has('unix')
+"     " Set nvim conf base directory path for Linux environments
+
+"     let g:d_nvim_base = '~/.config/nvim'
+
+" end
+
+if has('linux') || has('mac')
     let g:d_nvim_base = '~/.config/nvim'
-
+elseif has('win32') || has('win64')
+    let g:d_nvim_base = '~/AppData/Local/nvim'
 end
 
 " Set path to autoload/ with vim-plug's autoload script
@@ -53,42 +62,43 @@ let g:d_vimplug_conf = g:d_nvim_conf . '/vimplug'
 let g:d_vimplug_plugin_conf = g:d_vimplug_conf . '/plugin-conf'
 
 " Set script vars (local to init.vim) for *.vim files
-let s:f_environment_vim = g:d_nvim_conf . '/environment.vim'
-let s:f_key_mappings_vim = g:d_nvim_conf . '/key-mappings.vim'
-let s:f_autocmd_rules_vim = g:d_nvim_conf . '/autocmd-rules.vim'
-let s:f_vimplug_core = g:d_vimplug_conf . '/vimplug-core.vim'
-let s:f_plug_installs = g:d_vimplug_conf . '/plug-installs.vim'
+let g:f_environment_vim = g:d_nvim_conf . '/environment.vim'
+let g:f_key_mappings_vim = g:d_nvim_conf . '/key-mappings.vim'
+let g:f_autocmd_rules_vim = g:d_nvim_conf . '/autocmd-rules.vim'
+let g:f_vimplug_core = g:d_vimplug_conf . '/vimplug-core.vim'
+let g:f_plug_installs = g:d_vimplug_conf . '/plug-installs.vim'
 
 
 " Environment
 " if filereadable(expand('~/AppData/Local/nvim/conf/environment.vim'))
-if filereadable(expand(s:f_environment_vim))
+if filereadable(expand('g:f_environment_vim'))
     " source ~/AppData/Local/nvim/conf/environment.vim
-    source s:f_environment_vim
+    source g:f_environment_vim
 end
 
 " Mappings
 " if filereadable(expand('~/AppData/Local/nvim/conf/key-mappings.vim'))
-if filereadable(expand(s:f_key_mappings_vim))
+if filereadable(expand('g:f_key_mappings_vim'))
     " source ~/AppData/Local/nvim/conf/key-mappings.vim
-    source s:f_key_mappings_vim
+    source g:f_key_mappings_vim
 end
 
 " autocmd Rules
 " if filereadable(expand('~/AppData/Local/nvim/conf/autocmd-rules.vim'))
-if filereadable(expand(s:f_autocmd_rules_vim))
+if filereadable(expand('g:f_autocmd_rules_vim'))
     " source ~/AppData/Local/nvim/conf/autocmd-rules.vim
-    source s:f_autocmd_rules_vim
+    source g:f_autocmd_rules_vim
 end
 
 " Vim Plug plugin manager
 " if filereadable(expand('~/AppData/Local/nvim/conf/vimplug/vimplug-core.vim'))
-if filereadable(expand(s:f_vimplug_core))
+if filereadable(expand('g:f_vimplug_core'))
     " source ~/AppData/Local/nvim/conf/vimplug/vimplug-core.vim
+    source g:f_vimplug_core
 end
 
 " Loop over plugin configurations
 " for f in split(glob('~/AppData/Local/nvim/conf/plugin-conf/*.vim'), '\n')
-for f in split(glob(s:d_vimplug_plugin_conf), '\n')
+for f in split(glob('g:d_vimplug_plugin_conf'), '\n')
     exe 'source' f
 endfor


### PR DESCRIPTION
New global env variables for nvim config base paths initialized in init.vim

Detects Windows or Linux/Mac hosts & sets global variables before sourcing other configs.

Fix README backtics